### PR TITLE
Reverse iteration of vector when converting to sequence to preserve element order

### DIFF
--- a/ferret.org
+++ b/ferret.org
@@ -2711,8 +2711,9 @@ directly. count is O(n). conj puts the item at the front of the list.
 
   template <> var sequence::from(std_vector v) { 
     var ret;
-    for(ref it : v)
-      ret = runtime::cons(it,ret);
+    std::vector<var>::reverse_iterator rit;
+    for(rit = v.rbegin(); rit != v.rend(); rit++)
+      ret = runtime::cons(*rit,ret);
     return ret;
   }
   #endif


### PR DESCRIPTION
Use reverse iterator when using `cons` to construct a sequence from a `std::vector<var>`.

The conversion to a `sequence` from a `std::vector<var>` was reversing the order of the vector elements. As `cons` is faster for iteratively building a sequence, reverse iteration over the vector is an efficient way to preserve element order.